### PR TITLE
Add BrotliDecode filter (RFC 7932 / ISO 32000-2 Amendment 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
+    - name: Install system dependencies
+      run: sudo apt-get install -y cmake
     - name: Install dependencies
       run: mix deps.get
     - name: Run tests

--- a/lib/hopper/core/filter.ex
+++ b/lib/hopper/core/filter.ex
@@ -73,4 +73,5 @@ defmodule Hopper.Core.Filter do
   defp module!("DCTDecode"), do: Hopper.Core.Filters.DCTDecode
   defp module!("JPXDecode"), do: Hopper.Core.Filters.JPXDecode
   defp module!("Crypt"), do: Hopper.Core.Filters.Crypt
+  defp module!("BrotliDecode"), do: Hopper.Core.Filters.BrotliDecode
 end

--- a/lib/hopper/core/filters/brotli_decode.ex
+++ b/lib/hopper/core/filters/brotli_decode.ex
@@ -1,0 +1,16 @@
+defmodule Hopper.Core.Filters.BrotliDecode do
+  @moduledoc false
+
+  # BrotliDecode — ISO 32000-2:2020 Amendment 2
+  # Encoding: RFC 7932 (Brotli)
+
+  def encode(data, _params \\ nil) do
+    {:ok, compressed} = :brotli.encode(data)
+    compressed
+  end
+
+  def decode(data, _params \\ nil) do
+    {:ok, decompressed} = :brotli.decode(data)
+    decompressed
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule Hopper.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:kino, "~> 0.14", optional: true}
+      {:kino, "~> 0.14", optional: true},
+      {:brotli, "~> 0.3"}
     ]
   end
 end

--- a/test/hopper/core/filter_test.exs
+++ b/test/hopper/core/filter_test.exs
@@ -101,6 +101,34 @@ defmodule Hopper.Core.FilterTest do
     end
   end
 
+  describe "BrotliDecode" do
+    test "compresses data with brotli" do
+      data = "Hello, World!"
+      encoded = Filter.encode(data, Objects.name("BrotliDecode"))
+      {:ok, decompressed} = :brotli.decode(encoded)
+      assert decompressed == data
+    end
+
+    test "empty data" do
+      encoded = Filter.encode("", Objects.name("BrotliDecode"))
+      {:ok, decompressed} = :brotli.decode(encoded)
+      assert decompressed == ""
+    end
+
+    test "binary data" do
+      data = <<0, 1, 2, 3, 4, 5>>
+      encoded = Filter.encode(data, Objects.name("BrotliDecode"))
+      {:ok, decompressed} = :brotli.decode(encoded)
+      assert decompressed == data
+    end
+
+    test "round-trip encode then decode" do
+      data = "PDF brotli filter round-trip test"
+      encoded = Filter.encode(data, Objects.name("BrotliDecode"))
+      assert Filter.decode(encoded, Objects.name("BrotliDecode")) == data
+    end
+  end
+
   describe "pass-through filters" do
     test "DCTDecode passes data unchanged" do
       data = <<0xFF, 0xD8, 0xFF>>


### PR DESCRIPTION
Adds support for the BrotliDecode stream filter introduced in PDF 2.0
Amendment 2. Uses the :brotli NIF package (Google brotli, RFC 7932)
for compress/decompress. Registers the filter in the dispatch table
and adds round-trip tests.

https://claude.ai/code/session_01E36CY8zNXma2PfyCjV6LBH